### PR TITLE
define deepExtend, fixing "deepExtend is not defined" error

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@
  * If you wish to clone object, simply use that:
  *  deepExtend({}, yourObj_1, [yourObj_N]) - first arg is new empty object
  */
-module.exports = function (/*obj_1, [obj_2], [obj_N]*/) {
+module.exports = deepExtend = function (/*obj_1, [obj_2], [obj_N]*/) {
 	var target, key, val, src, clone, args = [], i = 1;
 	
 	if (arguments.length < 1 || typeof arguments[0] !== 'object') {


### PR DESCRIPTION
current npm version of deep-extend is broken, that's fix it
