### PR TITLE
Add support for Buffer values, and unit tests to prove it works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ var deepExtend = module.exports = function (/*obj_1, [obj_2], [obj_N]*/) {
 
             if (val === target) continue;
 
-            if (typeof val !== 'object' || val === null) {
+            if (typeof val !== 'object' || val === null || val instanceof Buffer) {
                 target[key] = val;
                 continue;
             }

--- a/package.json
+++ b/package.json
@@ -1,16 +1,23 @@
 {
-    "name": "deep-extend",
-    "description": "Recursive object extending.",
-    "license": "MIT",
-    "version": "0.2.8",
-    "homepage": "https://github.com/unclechu/node-deep-extend",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/unclechu/node-deep-extend.git"
-    },
-    "author": "Viacheslav Lotsmanov (unclechu) <lotsmanov89@gmail.com>",
-    "main": "index",
-    "engines": {
-        "node": ">=0.4"
-    }
+  "name": "deep-extend",
+  "description": "Recursive object extending.",
+  "license": "MIT",
+  "version": "0.2.8",
+  "homepage": "https://github.com/unclechu/node-deep-extend",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/unclechu/node-deep-extend.git"
+  },
+  "author": "Viacheslav Lotsmanov (unclechu) <lotsmanov89@gmail.com>",
+  "main": "index",
+  "engines": {
+    "node": ">=0.4"
+  },
+  "scripts": {
+    "test": "./node_modules/.bin/mocha"
+  },
+  "devDependencies": {
+    "mocha": "~1.19.0",
+    "should": "~3.3.2"
+  }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,0 +1,35 @@
+var should = require('should');
+var extend = require('../index');
+
+describe('deep-extend', function() {
+
+  it('can extend on 1 level', function() {
+    var a = { hello: 1 };
+    var b = { world: 2 };
+    extend(a, b);
+    a.should.eql({
+      hello: 1,
+      world: 2
+    });
+  });
+
+  it('can extend on 2 levels', function() {
+    var a = { person: { name: 'John' } };
+    var b = { person: { age: 30 } };
+    extend(a, b);
+    a.should.eql({
+      person: { name: 'John', age: 30 }
+    });
+  });
+
+  it('can extend with Buffer values', function() {
+    var a = { hello: 1 };
+    var b = { value: new Buffer('world') };
+    extend(a, b);
+    a.should.eql({
+      hello: 1,
+      value: new Buffer('world')
+    });
+  });
+
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--reporter spec


### PR DESCRIPTION
This adds support for objects with `Buffer` values, for example:

``` js
var a = { hello: 1 };
var b = { value: new Buffer('world') };
extend(a, b);
```

I also added unit tests to show it works:

```
$ npm install
$ npm test

    ✓ can extend on 1 level
    ✓ can extend on 2 levels
    ✓ can extend with Buffer values
```
