### PR TITLE
Error object is cloned as empty

### DIFF
--- a/lib/deep-extend.js
+++ b/lib/deep-extend.js
@@ -32,6 +32,7 @@ function isSpecificValue(val) {
 		val instanceof Buffer
 		|| val instanceof Date
 		|| val instanceof RegExp
+		|| val instanceof Error
 	) ? true : false;
 }
 
@@ -44,6 +45,8 @@ function cloneSpecificValue(val) {
 		return new Date(val.getTime());
 	} else if (val instanceof RegExp) {
 		return new RegExp(val);
+	} else if (val instanceof Error) {
+		return val;
 	} else {
 		throw new Error('Unexpected situation');
 	}

--- a/lib/deep-extend.js
+++ b/lib/deep-extend.js
@@ -46,10 +46,23 @@ function cloneSpecificValue(val) {
 	} else if (val instanceof RegExp) {
 		return new RegExp(val);
 	} else if (val instanceof Error) {
-		return val;
+		return deepCloneError(val);
 	} else {
 		throw new Error('Unexpected situation');
 	}
+}
+
+/**
+ * @param {Error} error
+ */
+function deepCloneError(error) {
+	var errorClone = new Error(error.message);
+	var names = Object.getOwnPropertyNames(error);
+	for (var name in names) {
+		errorClone[name] = error[name];
+	}
+	errorClone.stack = error.stack;
+	return errorClone;
 }
 
 /**

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -69,6 +69,18 @@ describe('deep-extend', function () {
 		b.d.lastIndex.should.not.eql( a.d.lastIndex );
 	});
 
+	it('Error objects', function () {
+		var a = { d: new Error('error') };
+		var b = extend({}, a);
+		b.d.should.instanceOf(Error);
+	});
+
+	it('Error object is cloned', function () {
+		var a = { d: new Error('error') };
+		var b = extend({}, a);
+		b.d.message.should.eql('error');
+	});
+
 	it('doesn\'t change sources', function () {
 		var a = {a: [1]};
 		var b = {a: [2]};


### PR DESCRIPTION
``` js
var deepExtend = require('deep-extend');

var a = {exceptionNormal: new Error('normal')};
deepExtend(a, {exceptionBroken: new Error('broken')});

console.log(a);
```

gives

```
{ exceptionNormal: 
   Error: normal
       at Object.<anonymous> (....)
  exceptionBroken: {} }
```
