### PR TITLE
Handle null/undefined arguments

### DIFF
--- a/lib/deep-extend.js
+++ b/lib/deep-extend.js
@@ -93,6 +93,11 @@ var deepExtend = module.exports = function (/*obj_1, [obj_2], [obj_N]*/) {
 	// convert arguments to array and cut off target object
 	var args = Array.prototype.slice.call(arguments, 1);
 
+  // filter out all null and undefined args
+  args = args.filter(function (arg) {
+    return arg !== null
+  });
+
 	var val, src, clone;
 
 	args.forEach(function (obj) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -217,4 +217,20 @@ describe('deep-extend', function () {
 		});
 	});
 
+	it('can handle null/undefined as an argument', function () {
+    var A = {
+      something: 'test',
+      another: 'test'
+    };
+    var B = null;
+    var C;
+    extend(A, B).should.eql({
+      something: 'test',
+      another: 'test'
+    });
+    extend(A, C).should.eql({
+      something: 'test',
+      another: 'test'
+    });
+	});
 });


### PR DESCRIPTION
This PR introduces the ability to properly handle `null` and `undefined` values as 2nd or later argument.

It filters the arguments, removing all, that are either `null` or `undefined`. Loose type comparison `arg !== null` is used. It works both for `null` and `undefined`, but returns `false` for `arg = false` 

[See MDN page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness)