### PR TITLE
Avoid using deprecated Buffer API

### DIFF
--- a/lib/deep-extend.js
+++ b/lib/deep-extend.js
@@ -37,7 +37,9 @@ function isSpecificValue(val) {
 
 function cloneSpecificValue(val) {
 	if (val instanceof Buffer) {
-		var x = new Buffer(val.length);
+		var x = Buffer.alloc
+			? Buffer.alloc(val.length)
+			: new Buffer(val.length);
 		val.copy(x);
 		return x;
 	} else if (val instanceof Date) {


### PR DESCRIPTION
Use `Buffer.alloc` when it's available instead of `new Bufer(number)`.

Fixes: https://github.com/unclechu/node-deep-extend/issues/37
Refs: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor
Tracking: https://github.com/nodejs/node/issues/19079