### PR TITLE
README: Fixing a mistake in the example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ console.log(obj1);
 /*
 { a: 1,
   b: 3,
-	c: 5,
+  c: 5,
   d:
    { a: 1,
      b: { first: 'one', second: 'two' },

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ console.log(obj1);
 /*
 { a: 1,
   b: 3,
+	c: 5,
   d:
    { a: 1,
      b: { first: 'one', second: 'two' },


### PR DESCRIPTION
When I was reading over the docs last night I was confused when the example code didn't copy a property from the second object into the first object. After trying out the code myself, however, I figured out it was just a small issue with the README.