### PR TITLE
Added power support for the travis.yml file with ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+arch:
+   - amd64
+   - ppc64le
 cache: yarn
 node_js:
   - "node"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ node_js:
   - "8"
   - "7"
   - "6"
-  - "5"
-  - "4"
-  - "4.0.0" # minimal supported version
 before_install:
   - npm config set strict-ssl false
   - npm config set registry="http://registry.npmjs.org/"


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing.
